### PR TITLE
fix: Token/Lexer API mismatch

### DIFF
--- a/include/hybridcompressor/Token.h
+++ b/include/hybridcompressor/Token.h
@@ -29,8 +29,8 @@ namespace hc {
         size_t column = 1;
         size_t offset = 0;
 
-    private:
         Token() = default;
+        Token(TokenType type, std::string value ,size_t line=1 ,size_t column=1 ,size_t offset=0) : type(type), value(value),line(line),column(column),offset(offset) {}
 
     public:
         static Token makeText(const std::string &val, size_t line = 1, size_t column = 1, size_t offset = 0) {

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -1,8 +1,5 @@
 ﻿#include "hybridcompressor/Lexer.h"
 
-// hc::Lexer::Lexer(std::string input_source) {
-//
-// }
 
 hc::Lexer::Lexer(std::string input_source) : source(std::move(input_source)) {
 }


### PR DESCRIPTION
Closes #1

Changes:
- Align Token and Lexer token construction to compile cleanly
- Keeps behavior consistent and unblocks build