### PR TITLE
fix: pybind enum binding and build errors

### DIFF
--- a/python/hybridcompressor/_native.cpp
+++ b/python/hybridcompressor/_native.cpp
@@ -17,7 +17,7 @@ PYBIND11_MODULE(_core, m) {
             .value("END_TAG", hc::TokenType::END_TAG)
             .value("TEXT", hc::TokenType::TEXT)
             .value("COMMENT", hc::TokenType::COMMENT)
-            .value("ATTRIBUTE", hc::TokenType::ATTRIBUTE)
+            // .value("ATTRIBUTE", hc::TokenType::ATTRIBUTE)
             .value("ATTRIBUTE_NAME", hc::TokenType::ATTRIBUTE_NAME)
             .value("ATTRIBUTE_VALUE", hc::TokenType::ATTRIBUTE_VALUE)
             .value("SELF_CLOSING_TAG", hc::TokenType::SELF_CLOSING_TAG)


### PR DESCRIPTION
Closes #2

Changes:
- Fix TokenType enum bindings to match C++ TokenType
- Unblock Windows build for _core module