### PR TITLE
build: link Lexer.cpp into HybridCompressor_Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ add_custom_command(
 
 add_executable(HybridCompressor_Test src/main.cpp
         include/hybridcompressor/HybridCompressor.h
-        src/HybridCompressor.cpp)
+        src/HybridCompressor.cpp
+        src/Lexer.cpp)
 target_include_directories(HybridCompressor_Test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )


### PR DESCRIPTION
Closes #3

- Ensure HybridCompressor_Test links Lexer.cpp so the smoke test executable builds on Windows