### PR TITLE
test: add lexer regression test runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,70 +1,64 @@
-﻿#cmake_minimum_required(VERSION 3.15)
-#project(HybridCompressor)
-#
-#set(CMAKE_CXX_STANDARD 17)
-#set(CMAKE_CXX_STANDARD_REQUIRED ON)
-#
-#
-#add_subdirectory(pybind11)
-#
-#file(GLOB LIB_SOURCES
-#
-#)
-#
-#pybind11_add_module(hybridcompressor
-#        main.cpp
-#        ${LIB_SOURCES}
-#)
-#
-#target_include_directories(hybridcompressor PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
-#
-#add_custom_command(
-#        TARGET hybridcompressor POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#        $<TARGET_FILE:hybridcompressor>
-#        "${CMAKE_CURRENT_SOURCE_DIR}/python/hybridcompressor.pyd"
-#        COMMENT "✅ Copying compiled module to python directory..."
-#)
-
-
-
-
-cmake_minimum_required(VERSION 3.15)
+﻿cmake_minimum_required(VERSION 3.15)
 project(HybridCompressor VERSION 1.0.0 LANGUAGES CXX)
 
+# ---- C++ Standard ----
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Optional: enable IPO/LTO in Release builds (safe default)
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+if(IPO_SUPPORTED)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+endif()
+
+# ---- Dependencies ----
 add_subdirectory(pybind11)
 
-file(GLOB CORE_SOURCES
+# ---- Core library (shared by executables + python module) ----
+add_library(hc_core STATIC
         src/Lexer.cpp
         src/Parser.cpp
         src/HybridCompressor.cpp
 )
 
-set(PYTHON_BINDINGS_SOURCE python/hybridcompressor/_native.cpp)
-
-pybind11_add_module(_core MODULE ${PYTHON_BINDINGS_SOURCE} ${CORE_SOURCES})
-
-target_include_directories(_core PRIVATE
+target_include_directories(hc_core PUBLIC
         "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
+# If you ever need platform-specific definitions:
+# target_compile_definitions(hc_core PUBLIC ...)
+
+# ---- Python bindings (_core.pyd / .so) ----
+set(PYTHON_BINDINGS_SOURCE python/hybridcompressor/_native.cpp)
+
+pybind11_add_module(_core MODULE
+        ${PYTHON_BINDINGS_SOURCE}
+)
+
+target_link_libraries(_core PRIVATE hc_core)
+
+# Copy built module into python package folder after build
 add_custom_command(
         TARGET _core POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/python/hybridcompressor"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:_core>
         "${CMAKE_CURRENT_SOURCE_DIR}/python/hybridcompressor/$<TARGET_FILE_NAME:_core>"
         COMMENT "✅ Copying compiled module to python package directory..."
 )
 
-add_executable(HybridCompressor_Test src/main.cpp
-        include/hybridcompressor/HybridCompressor.h
-        src/HybridCompressor.cpp
-        src/Lexer.cpp)
-target_include_directories(HybridCompressor_Test PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+# ---- Smoke test executable ----
+add_executable(HybridCompressor_Test
+        src/main.cpp
 )
+
+target_link_libraries(HybridCompressor_Test PRIVATE hc_core)
+
+# ---- Lexer regression tests executable ----
+add_executable(Lexer_Tests
+        tests/lexer_tests.cpp
+)
+
+target_link_libraries(Lexer_Tests PRIVATE hc_core)

--- a/tests/lexer_tests.cpp
+++ b/tests/lexer_tests.cpp
@@ -1,0 +1,104 @@
+﻿#include <vector>
+#include <string>
+#include <iostream>
+
+#include "hybridcompressor/Lexer.h"
+#include "hybridcompressor/Token.h"
+
+using hc::Lexer;
+using hc::Token;
+using hc::TokenType;
+
+struct ExpectedToken {
+    TokenType type;
+    std::string value;
+};
+
+std::vector<ExpectedToken> tokenize(const std::string &input) {
+    Lexer lexer(input);
+    std::vector<ExpectedToken> tokens;
+
+    while (true) {
+        Token t = lexer.getNextToken();
+
+        if (t.type == TokenType::END_OF_FILE) {
+            break;
+        }
+
+        tokens.push_back({t.type, t.value});
+    }
+
+    return tokens;
+}
+
+bool runCase(const std::string &name, const std::string &input, const std::vector<ExpectedToken> &expected) {
+    std::vector<ExpectedToken> got = tokenize(input);
+
+    if (got.size() != expected.size()) {
+        std::cout << "[FAIL] " << name << " token count mismatch\n";
+        std::cout << "Expected: " << expected.size()
+                << " Got: " << got.size() << "\n";
+        return false;
+    }
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        if (got[i].type != expected[i].type || got[i].value != expected[i].value) {
+            std::cout << "[FAIL] " << name << " mismatch at index " << i << "\n";
+            std::cout << "Expected: (" << static_cast<int>(expected[i].type)
+                    << ", " << expected[i].value << ")\n";
+            std::cout << "Got: (" << static_cast<int>(got[i].type)
+                    << ", " << got[i].value << ")\n";
+            return false;
+        }
+    }
+
+    std::cout << "[PASS] " << name << "\n";
+    return true;
+}
+
+int main() {
+    int failedCount = 0;
+
+    failedCount += !runCase("simple_div", "<div>hi</div>", {
+                                {TokenType::START_TAG, "div"},
+                                {TokenType::TEXT, "hi"},
+                                {TokenType::END_TAG, "div"}
+                            });
+
+    failedCount += !runCase("attr_quoted", R"(<div class="a">x</div>)", {
+                                {TokenType::START_TAG, "div"},
+                                {TokenType::ATTRIBUTE_NAME, "class"},
+                                {TokenType::ATTRIBUTE_VALUE, "a"},
+                                {TokenType::TEXT, "x"},
+                                {TokenType::END_TAG, "div"}
+                            });
+
+    failedCount += !runCase("attr_unquoted", "<input type=text>", {
+                                {TokenType::START_TAG, "input"},
+                                {TokenType::ATTRIBUTE_NAME, "type"},
+                                {TokenType::ATTRIBUTE_VALUE, "text"}
+                            });
+
+    failedCount += !runCase("self_closing", "<br/>", {
+                                {TokenType::SELF_CLOSING_TAG, "br"}
+                            });
+    failedCount += !runCase("comment", "<!--hello-->", {
+                                {TokenType::COMMENT, "hello"}
+                            });
+
+    failedCount += !runCase("nested_text", "<div><span>ok</span></div>", {
+                                {TokenType::START_TAG, "div"},
+                                {TokenType::START_TAG, "span"},
+                                {TokenType::TEXT, "ok"},
+                                {TokenType::END_TAG, "span"},
+                                {TokenType::END_TAG, "div"}
+                            });
+
+    if (failedCount == 0) {
+        std::cout << "All lexer tests passed.\n";
+        return 0;
+    }
+
+    std::cout << failedCount << " lexer test(s) failed.\n";
+    return 1;
+}


### PR DESCRIPTION
Add a lightweight lexer regression test runner with core tokenization cases.

Covers:
- simple tags
- quoted attributes
- unquoted attributes
- self-closing tags
- comments
- nested text